### PR TITLE
Removes req.body from authenticate http request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,6 @@ class Kable {
         [X_CLIENT_ID_HEADER_KEY]: clientId || "",
         [X_API_KEY_HEADER_KEY]: secretKey || "",
       },
-      data: req.body,
     })
       .then((response: any) => {
         const status = response.status;


### PR DESCRIPTION
## Description
Resolves #5 by removing the request body from the `/authenticate` HTTP request sent to Kable

## Testing
I've been using this fork in my project today in place of the npm package. We received about 20 live authenticate requests without issue.

@adamsommer fyi
